### PR TITLE
Added translation functionality to the Mboathoscope App using GetX translation

### DIFF
--- a/Mboathoscope/lib/main.dart
+++ b/Mboathoscope/lib/main.dart
@@ -1,46 +1,62 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:mboathoscope/controller/appDirectorySingleton.dart';
+import 'package:mboathoscope/utils/localization.dart';
 import 'package:mboathoscope/views/LoginPage.dart';
 import 'package:mboathoscope/views/RolePage.dart';
 import 'package:mboathoscope/views/StartPage.dart';
 import 'package:mboathoscope/views/homePage.dart';
 import 'package:provider/provider.dart' as provider;
-import 'package:firebase_core/firebase_core.dart';
+
 import 'models/User.dart';
 
-
-
-
-
-void main() async{
-
+void main() async {
   ///
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
   await AppDirectorySingleton().getAppDirectory();
   await AppDirectorySingleton().fetchRecordings();
+  WidgetsFlutterBinding.ensureInitialized();
+  await LocalizationService.initLanguages();
 
-  runApp(
-      provider.MultiProvider(
-        providers: [
-          provider.ChangeNotifierProvider<AppDirectorySingleton>(create: (_) => AppDirectorySingleton()),
-        ],
-        child: MaterialApp(
-          theme: ThemeData(
-            primarySwatch: Colors.blue,
-          ),
-          home: const StartPage(),
-          debugShowCheckedModeBanner: false,
-          initialRoute: '/',
-          routes: {
-            '': (context) => const StartPage(),
-            '/rolepage': (context) => RolePage(user: CustomUser(uid: '', fullName: "", phoneNumber: '', age: '', gender: '', email: ''),),
-
-            '/login': (context) => const LoginPage(),
-            '/homepage': (context) => HomePage(user: CustomUser(uid: '', fullName: "", phoneNumber: '', age: '', gender: '', email: ''),),
-          },
-        ),
-      )
-  );
+  runApp(provider.MultiProvider(
+    providers: [
+      provider.ChangeNotifierProvider<AppDirectorySingleton>(
+          create: (_) => AppDirectorySingleton()),
+    ],
+    child: GetMaterialApp(
+      //locale: Locale('fr', 'FR'),
+      locale: Get.deviceLocale,
+      fallbackLocale: const Locale('en', 'US'),
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const StartPage(),
+      debugShowCheckedModeBanner: false,
+      initialRoute: '/',
+      routes: {
+        '': (context) => const StartPage(),
+        '/rolepage': (context) => RolePage(
+              user: CustomUser(
+                  uid: '',
+                  fullName: "",
+                  phoneNumber: '',
+                  age: '',
+                  gender: '',
+                  email: ''),
+            ),
+        '/login': (context) => const LoginPage(),
+        '/homepage': (context) => HomePage(
+              user: CustomUser(
+                  uid: '',
+                  fullName: "",
+                  phoneNumber: '',
+                  age: '',
+                  gender: '',
+                  email: ''),
+            ),
+      },
+    ),
+  ));
 }
-

--- a/Mboathoscope/lib/utils/localization.dart
+++ b/Mboathoscope/lib/utils/localization.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+
+Map localization = <String, Map>{};
+
+class LocalizationService extends Translations {
+  @override
+  Map<String, Map<String, String>> get keys => {};
+
+  static Future<void> initLanguages() async {
+    final Map<String, Map<String, String>> keys = {};
+
+    final languages = ['en_US', 'fr_FR'];
+
+    for (final lang in languages) {
+      final languageKeys = await readJson(lang);
+      keys[lang] = languageKeys;
+      localization[lang] = languageKeys;
+    }
+
+    Get.clearTranslations();
+    Get.addTranslations(keys);
+  }
+
+  static Future<Map<String, String>> readJson(String languageCode) async {
+    final res = await rootBundle.loadString('translations/$languageCode.json');
+    final List<dynamic> data = jsonDecode(res);
+
+    final languageKeys = <String, String>{};
+    for (final entry in data) {
+      final String key = entry['ResourceKey'];
+      final String value = entry['ResourceValue'];
+      languageKeys[key] = value;
+    }
+    return languageKeys;
+  }
+}

--- a/Mboathoscope/lib/views/LoginPage.dart
+++ b/Mboathoscope/lib/views/LoginPage.dart
@@ -1,13 +1,15 @@
+import 'package:cloud_firestore/cloud_firestore.dart' as cft;
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:lottie/lottie.dart';
 import 'package:mboathoscope/controller/helpers.dart';
 import 'package:mboathoscope/utils/shared_preference.dart';
 import 'package:mboathoscope/views/RegisterPage.dart';
-import 'package:lottie/lottie.dart';
 import 'package:mboathoscope/views/RolePage.dart';
 import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
+
 import '../models/User.dart';
-import 'package:cloud_firestore/cloud_firestore.dart' as cft;
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -157,7 +159,7 @@ class _LoginPageState extends State<LoginPage> {
               borderSide: BorderSide(color: Colors.white60)),
           errorStyle: const TextStyle(color: Colors.red),
           errorText: errorText,
-          hintText: "Email",
+          hintText: "Email".tr,
           hintStyle: const TextStyle(fontSize: 18.0, color: Colors.white70),
           border: InputBorder.none,
         ));
@@ -188,7 +190,7 @@ class _LoginPageState extends State<LoginPage> {
               borderSide: BorderSide(color: Colors.white60)),
           errorStyle: const TextStyle(color: Colors.red),
           errorText: passwordErrorText,
-          hintText: "Password",
+          hintText: "Password".tr,
           hintStyle: const TextStyle(fontSize: 18.0, color: Colors.white70),
           border: InputBorder.none,
         ));
@@ -221,7 +223,7 @@ class _LoginPageState extends State<LoginPage> {
               signInWithEmailAndPassword();
             },
             child: Text(
-              "Login",
+              "Login".tr,
               textAlign: TextAlign.center,
               style: TextStyle(
                   fontSize: 20,
@@ -254,7 +256,7 @@ class _LoginPageState extends State<LoginPage> {
                         SizedBox(
                           height: h * .1,
                           child: Text(
-                            'Login',
+                            'Login'.tr,
                             style: TextStyle(
                               color: Color(0xff3D79FD),
                               fontWeight: FontWeight.bold,
@@ -278,10 +280,10 @@ class _LoginPageState extends State<LoginPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
                               Text(
-                                "Don't have an account? ",
+                                "NoAccount".tr,
                                 style: TextStyle(
                                   color: Colors.blueGrey,
-                                  fontSize: h * .025,
+                                  fontSize: h * .021,
                                 ),
                               ),
                               GestureDetector(
@@ -293,7 +295,7 @@ class _LoginPageState extends State<LoginPage> {
                                               RegisterPage()));
                                 },
                                 child: Text(
-                                  "Register",
+                                  "Register".tr,
                                   style: TextStyle(
                                     color: Color(0xff3D79FD),
                                     fontWeight: FontWeight.bold,

--- a/Mboathoscope/lib/views/StartPage.dart
+++ b/Mboathoscope/lib/views/StartPage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:mboathoscope/utils/shared_preference.dart';
 import 'package:mboathoscope/views/buttons/CustomButton.dart';
 
@@ -76,10 +77,10 @@ class _StartPageState extends State<StartPage> {
                       onTap: () {
                         Navigator.pushNamed(context, '/login');
                       },
-                      child: const Padding(
+                      child: Padding(
                         padding: EdgeInsets.only(bottom: 199),
                         child: CustomButton(
-                          txt: 'Get Started',
+                          txt: 'GetStarted'.tr,
                         ),
                       ),
                     )

--- a/Mboathoscope/pubspec.lock
+++ b/Mboathoscope/pubspec.lock
@@ -360,6 +360,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.2"
+  get:
+    dependency: "direct main"
+    description:
+      name: get
+      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.6"
   http:
     dependency: transitive
     description:
@@ -935,4 +943,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.13.0"

--- a/Mboathoscope/pubspec.yaml
+++ b/Mboathoscope/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   ffmpeg_kit_flutter:
   shared_preferences: ^2.2.2
   modal_progress_hud_nsn: ^0.4.0
+  get: ^4.6.6
 
 
 
@@ -93,6 +94,7 @@ flutter:
   assets:
     - assets/images/
     - assets/animations/
+    - translations/
     
     # - assets/images/img.png
     # - assets/images/img_role.png

--- a/Mboathoscope/translations/en_US.json
+++ b/Mboathoscope/translations/en_US.json
@@ -1,0 +1,37 @@
+[
+  {
+    "ResourceKey": "Login",
+    "ResourceValue": "Login",
+    "LanguageId": 1
+  },
+
+  {
+    "ResourceKey": "NoAccount",
+    "ResourceValue": "Don't have an account? ",
+    "LanguageId": 1
+
+  },
+  {
+    "ResourceKey": "Register",
+    "ResourceValue": "Register",
+    "LanguageId": 1
+
+  },
+  {
+    "ResourceKey": "Password",
+    "ResourceValue": "Password",
+    "LanguageId": 1
+
+  },
+  {
+    "ResourceKey": "Email",
+    "ResourceValue": "Email",
+    "LanguageId": 1
+
+  },
+  {
+    "ResourceKey": "GetStarted",
+    "ResourceValue": "Get Started",
+    "LanguageId": 1
+  }
+]

--- a/Mboathoscope/translations/fr_FR.json
+++ b/Mboathoscope/translations/fr_FR.json
@@ -1,0 +1,37 @@
+[
+  {
+    "ResourceKey": "Login",
+    "ResourceValue": "Se connecter",
+    "LanguageId": 2
+  },
+
+  {
+    "ResourceKey": "NoAccount",
+    "ResourceValue": "Vous n'avez pas de compte? ",
+    "LanguageId": 2
+
+  },
+  {
+    "ResourceKey": "Register",
+    "ResourceValue": "Registre",
+    "LanguageId": 2
+
+  },
+  {
+    "ResourceKey": "Password",
+    "ResourceValue": "Mot de passe",
+    "LanguageId": 2
+
+  },
+  {
+    "ResourceKey": "Email",
+    "ResourceValue": "Email",
+    "LanguageId": 2
+
+  },
+  {
+    "ResourceKey": "GetStarted",
+    "ResourceValue": "Commencer",
+    "LanguageId": 2
+  }
+]


### PR DESCRIPTION
This pull request introduces translation functionality to the Mboathoscope app, leveraging the GetX translation library.

 Changes:

**Translations Folder:** I created a new folder named "translations" which contains translation JSON files. Currently, JSON file translations for English and French have been added which contain translations for the Login Page.

**Localization Util File:** Within the "util" folder, I created a new Dart file named "localization". This file is responsible for reading and applying the translations from the various JSON files.

These changes make the app more accessible by enabling support for multiple languages through a structured translation framework.

@ruqaiyasattar please review the change if it is ok with you I will go ahead and include translations for the other screens

# Login Screen in English
![image](https://github.com/Mboalab/Outreachy-23-MboaLab/assets/122117063/8bd44ae3-bf93-4010-ac6e-bd53d513ba79)



# Login Screen in French
![image](https://github.com/Mboalab/Outreachy-23-MboaLab/assets/122117063/fce352ef-800f-443f-a61f-c796a91ffdc7)

